### PR TITLE
fix additional_rules.py terminology.py to p/utils/additional_to read files with utf-8 encoding

### DIFF
--- a/app/utils/additional_rules.py
+++ b/app/utils/additional_rules.py
@@ -17,6 +17,6 @@ def search_additional_rules(query:str) -> list[AditionalRule]:
 def __init__():
     global additional_rules
     
-    file = open(ADDITIONAL_RULES_FILE_PATH, "r")
+    file = open(ADDITIONAL_RULES_FILE_PATH, "r", encoding='utf-8')
     data = json.load(file)
     additional_rules = [AditionalRule(**rule) for rule in data]                                   

--- a/app/utils/terminology.py
+++ b/app/utils/terminology.py
@@ -17,6 +17,6 @@ def search_terminology(query: str, category: TermCategory | None = None) -> list
 def __init__():
     global terminology
     
-    file = open(TERMINOLOGY_FILE_PATH, "r")
+    file = open(TERMINOLOGY_FILE_PATH, "r", encoding='utf-8')
     data = json.load(file)
     terminology = [Term(**glossary) for glossary in data]                                   


### PR DESCRIPTION
This pull request updates file reading operations to specify UTF-8 encoding when loading JSON data for additional rules and terminology. This change helps prevent character encoding issues when processing files that may contain non-ASCII characters.

File handling improvements:

* Updated `app/utils/additional_rules.py` to open `ADDITIONAL_RULES_FILE_PATH` with `encoding='utf-8'` when loading additional rules.
* Updated `app/utils/terminology.py` to open `TERMINOLOGY_FILE_PATH` with `encoding='utf-8'` when loading terminology.